### PR TITLE
Integrate the dd api stub

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,3 +5,9 @@ var BindAddr = ":20030"
 
 // RendererURL is the address of the frontend renderer service.
 var RendererURL = "http://localhost:20010"
+
+// DiscoveryAPIURL is the address of the data discovery REST API service.
+var DiscoveryAPIURL = "http://localhost:20099"
+
+// ExternalURL is the base URL through which users are accessing the service.
+var ExternalURL = "http://localhost:20000/dd"

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,0 +1,87 @@
+package discovery
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ONSdigital/dp-dd-frontend-controller/config"
+	"github.com/ONSdigital/dp-frontend-models/model/dd"
+	"github.com/ONSdigital/go-ns/log"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// ListDatasets lists the available datasets by querying the DD API.
+func ListDatasets() (datasets *dd.Datasets, err error) {
+	request, err := http.NewRequest("GET", config.DiscoveryAPIURL+"/datasets", nil)
+	if err != nil {
+		log.Error(err, nil)
+		return
+	}
+
+	res, err := http.DefaultClient.Do(request)
+	if err != nil {
+		log.ErrorR(request, err, nil)
+		return
+	}
+	defer checkClose(res.Body)
+
+	if res.StatusCode != http.StatusOK {
+		err = fmt.Errorf("discovery.ListDatasets: unexpected status code from API: %d", res.StatusCode)
+		return
+	}
+
+	datasetsJSON, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.ErrorR(request, err, nil)
+		return
+	}
+
+	if err = json.Unmarshal(datasetsJSON, &datasets); err != nil {
+		log.ErrorR(request, err, nil)
+		return
+	}
+
+	return
+}
+
+// GetDataset retrieves metadata and dimension info for a dataset.
+func GetDataset(id string) (dataset *dd.Dataset, err error) {
+	request, err := http.NewRequest("GET", config.DiscoveryAPIURL+"/datasets/"+id, nil)
+	if err != nil {
+		log.Error(err, nil)
+		return
+	}
+
+	res, err := http.DefaultClient.Do(request)
+	if err != nil {
+		log.ErrorR(request, err, nil)
+		return
+	}
+	defer checkClose(res.Body)
+
+	if res.StatusCode != http.StatusOK {
+		err = fmt.Errorf("discovery.GetDataset: unexpected status code from API: %d", res.StatusCode)
+		return
+	}
+
+	datasetJSON, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.ErrorR(request, err, nil)
+		return
+	}
+
+	if err = json.Unmarshal(datasetJSON, &dataset); err != nil {
+		log.ErrorR(request, err, nil)
+		return
+	}
+
+	return
+
+}
+
+func checkClose(c io.Closer) {
+	if err := c.Close(); err != nil {
+		log.Error(err, nil)
+	}
+}

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1,0 +1,118 @@
+package discovery
+
+import (
+	"github.com/ONSdigital/dp-dd-frontend-controller/config"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ONSdigital/dp-frontend-models/model/dd"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestListDatasets(t *testing.T) {
+	var json []byte
+	statusCode := http.StatusOK
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
+		w.Write(json)
+	}))
+	defer ts.Close()
+
+	config.DiscoveryAPIURL = ts.URL
+
+	Convey("ListDatasets returns empty list if no datasets registered", t, func() {
+		statusCode = http.StatusOK
+		json = []byte(`{"items":[],"total":0}`)
+		datasets, err := ListDatasets()
+		So(err, ShouldBeNil)
+		So(datasets, ShouldNotBeNil)
+		So(datasets.Items, ShouldBeEmpty)
+	})
+
+	Convey("ListDatasets returns accurate dataset metadata", t, func() {
+		statusCode = http.StatusOK
+		json = []byte(`{"items":[{"id":"one","title":"title one","url":"url1", "metadata":{"description":"test description"}}],"total":1}`)
+		datasets, err := ListDatasets()
+		So(err, ShouldBeNil)
+		So(datasets, ShouldNotBeNil)
+		So(datasets.Items, ShouldHaveLength, 1)
+		So(datasets.Items[0], ShouldResemble, &dd.Dataset{
+			ID:    "one",
+			Title: "title one",
+			URL:   "url1",
+			Metadata: &dd.Metadata{
+				Description: "test description",
+			},
+		})
+	})
+
+	Convey("ListDatasets returns error if API is unavailable", t, func() {
+		statusCode = http.StatusServiceUnavailable
+		_, err := ListDatasets()
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("ListDatasets returns error if API is unreachable", t, func() {
+		config.DiscoveryAPIURL = "an-unreachable-address"
+		defer func() { config.DiscoveryAPIURL = ts.URL }()
+		_, err := ListDatasets()
+		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestGetDataset(t *testing.T) {
+	var json []byte
+	statusCode := http.StatusOK
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
+		w.Write(json)
+	}))
+	defer ts.Close()
+
+	config.DiscoveryAPIURL = ts.URL
+
+	Convey("GetDataset returns error if dataset does not exist", t, func() {
+		statusCode = http.StatusNotFound
+		_, err := GetDataset("foo")
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("GetDataset returns accurate dataset information", t, func() {
+		statusCode = http.StatusOK
+		json = []byte(`{"id":"one","title":"title one","url":"url1","metadata":{"description":"test description"},"dimensions":[{"id":"a","name":"A"}]}`)
+		dataset, err := GetDataset("one")
+		So(err, ShouldBeNil)
+		So(dataset, ShouldNotBeNil)
+		var dimensions []*dd.Dimension
+		dimensions = make([]*dd.Dimension, 1)
+		dimensions[0] = &dd.Dimension{
+			ID:   "a",
+			Name: "A",
+		}
+		So(dataset, ShouldResemble, &dd.Dataset{
+			ID:    "one",
+			Title: "title one",
+			URL:   "url1",
+			Metadata: &dd.Metadata{
+				Description: "test description",
+			},
+			Dimensions: dimensions,
+		})
+	})
+
+	Convey("GetDataset returns error if API is unavailable", t, func() {
+		statusCode = http.StatusServiceUnavailable
+		_, err := GetDataset("test")
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("ListDatasets returns error if API is unreachable", t, func() {
+		config.DiscoveryAPIURL = "an-unreachable-address"
+		defer func() { config.DiscoveryAPIURL = ts.URL }()
+		_, err := GetDataset("test")
+		So(err, ShouldNotBeNil)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ONSdigital/dp-dd-frontend-controller/config"
+	"github.com/ONSdigital/dp-dd-frontend-controller/handlers/dataset"
 	"github.com/ONSdigital/dp-dd-frontend-controller/handlers/homepage"
 	"github.com/ONSdigital/go-ns/handlers/requestID"
 	"github.com/ONSdigital/go-ns/handlers/timeout"
@@ -23,6 +24,14 @@ func main() {
 		config.RendererURL = v
 	}
 
+	if v := os.Getenv("DISCOVERY_API_URL"); len(v) > 0 {
+		config.DiscoveryAPIURL = v
+	}
+
+	if v := os.Getenv("EXTERNAL_URL"); len(v) > 0 {
+		config.ExternalURL = v
+	}
+
 	log.Namespace = "dp-dd-frontend-controller"
 
 	router := pat.New()
@@ -34,9 +43,12 @@ func main() {
 
 	router.HandleFunc("/dd", homepage.Handler)
 	router.HandleFunc("/dd/", homepage.Handler)
+	router.Get("/dd/dataset/{id}", dataset.Handler)
 
 	log.Debug("Starting server", log.Data{
-		"bind_addr": config.BindAddr,
+		"bind_addr":         config.BindAddr,
+		"renderer_url":      config.RendererURL,
+		"discovery_api_url": config.DiscoveryAPIURL,
 	})
 
 	server := &http.Server{

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dd/dataset/model.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dd/dataset/model.go
@@ -1,0 +1,12 @@
+package dataset
+
+import (
+	"github.com/ONSdigital/dp-frontend-models/model"
+	"github.com/ONSdigital/dp-frontend-models/model/dd"
+)
+
+// Page contains model data for a dataset page
+type Page struct {
+	model.Page
+	Dataset *dd.Dataset `json:"dataset"`
+}

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dd/discovery.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dd/discovery.go
@@ -1,0 +1,54 @@
+package dd
+
+// Datasets represents a set of available datasets.
+type Datasets struct {
+	Items        []*Dataset `json:"items,omitempty"`
+	Count        int        `json:"count"`
+	Total        int        `json:"total"`
+	StartIndex   int        `json:"startIndex"`
+	ItemsPerPage int        `json:"itemsPerPage"`
+}
+
+// Dataset represents the details about a particular dataset.
+type Dataset struct {
+	ID         string       `json:"id"`
+	Title      string       `json:"title"`
+	URL        string       `json:"url,omitempty"`
+	Metadata   *Metadata    `json:"metadata,omitempty"`
+	Dimensions []*Dimension `json:"dimensions,omitempty"`
+	Data       *Table       `json:"data,omitempty"`
+}
+
+// Metadata about a dataset.
+type Metadata struct {
+	Description string   `json:"description,omitempty"`
+	Taxonomies  []string `json:"taxonomies,omitempty"`
+}
+
+// Dimension of a dataset.
+type Dimension struct {
+	ID   string `json:"id"`
+	Name string `json:"name"` // Sex
+
+	Options        []*DimensionOption `json:"options,omitempty"`
+	SelectedOption *DimensionOption   `json:"selectedOption,omitempty"`
+}
+
+// DimensionOption describes a possible value for a dimension.
+type DimensionOption struct {
+	ID   string `json:"id"`
+	Name string `json:"name"` // Male
+
+	Options []*DimensionOption `json:"options,omitempty"`
+}
+
+// Row is a particular data point in a dataset.
+type Row struct {
+	Observation interface{}        // 123
+	Dimensions  []*DimensionOption // Sex=Male
+}
+
+// Table is a set of rows in a dataset.
+type Table struct {
+	Rows []*Row
+}

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/dd/homepage/model.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/dd/homepage/model.go
@@ -1,8 +1,12 @@
 package homepage
 
-import "github.com/ONSdigital/dp-frontend-models/model"
+import (
+	"github.com/ONSdigital/dp-frontend-models/model"
+	"github.com/ONSdigital/dp-frontend-models/model/dd"
+)
 
 // Homepage contains model data for the Data Discovery homepage
 type Homepage struct {
 	model.Page
+	Datasets *dd.Datasets `json:"datasets"`
 }

--- a/vendor/github.com/smartystreets/goconvey/LICENSE.md
+++ b/vendor/github.com/smartystreets/goconvey/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright (c) 2016 SmartyStreets, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+NOTE: Various optional and subordinate components carry their own licensing
+requirements and restrictions.  Use of those components is subject to the terms
+and conditions outlined the respective license of each component.

--- a/vendor/github.com/smartystreets/goconvey/convey/assertions.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/assertions.go
@@ -1,0 +1,68 @@
+package convey
+
+import "github.com/smartystreets/assertions"
+
+var (
+	ShouldEqual          = assertions.ShouldEqual
+	ShouldNotEqual       = assertions.ShouldNotEqual
+	ShouldAlmostEqual    = assertions.ShouldAlmostEqual
+	ShouldNotAlmostEqual = assertions.ShouldNotAlmostEqual
+	ShouldResemble       = assertions.ShouldResemble
+	ShouldNotResemble    = assertions.ShouldNotResemble
+	ShouldPointTo        = assertions.ShouldPointTo
+	ShouldNotPointTo     = assertions.ShouldNotPointTo
+	ShouldBeNil          = assertions.ShouldBeNil
+	ShouldNotBeNil       = assertions.ShouldNotBeNil
+	ShouldBeTrue         = assertions.ShouldBeTrue
+	ShouldBeFalse        = assertions.ShouldBeFalse
+	ShouldBeZeroValue    = assertions.ShouldBeZeroValue
+
+	ShouldBeGreaterThan          = assertions.ShouldBeGreaterThan
+	ShouldBeGreaterThanOrEqualTo = assertions.ShouldBeGreaterThanOrEqualTo
+	ShouldBeLessThan             = assertions.ShouldBeLessThan
+	ShouldBeLessThanOrEqualTo    = assertions.ShouldBeLessThanOrEqualTo
+	ShouldBeBetween              = assertions.ShouldBeBetween
+	ShouldNotBeBetween           = assertions.ShouldNotBeBetween
+	ShouldBeBetweenOrEqual       = assertions.ShouldBeBetweenOrEqual
+	ShouldNotBeBetweenOrEqual    = assertions.ShouldNotBeBetweenOrEqual
+
+	ShouldContain       = assertions.ShouldContain
+	ShouldNotContain    = assertions.ShouldNotContain
+	ShouldContainKey    = assertions.ShouldContainKey
+	ShouldNotContainKey = assertions.ShouldNotContainKey
+	ShouldBeIn          = assertions.ShouldBeIn
+	ShouldNotBeIn       = assertions.ShouldNotBeIn
+	ShouldBeEmpty       = assertions.ShouldBeEmpty
+	ShouldNotBeEmpty    = assertions.ShouldNotBeEmpty
+	ShouldHaveLength    = assertions.ShouldHaveLength
+
+	ShouldStartWith           = assertions.ShouldStartWith
+	ShouldNotStartWith        = assertions.ShouldNotStartWith
+	ShouldEndWith             = assertions.ShouldEndWith
+	ShouldNotEndWith          = assertions.ShouldNotEndWith
+	ShouldBeBlank             = assertions.ShouldBeBlank
+	ShouldNotBeBlank          = assertions.ShouldNotBeBlank
+	ShouldContainSubstring    = assertions.ShouldContainSubstring
+	ShouldNotContainSubstring = assertions.ShouldNotContainSubstring
+
+	ShouldPanic        = assertions.ShouldPanic
+	ShouldNotPanic     = assertions.ShouldNotPanic
+	ShouldPanicWith    = assertions.ShouldPanicWith
+	ShouldNotPanicWith = assertions.ShouldNotPanicWith
+
+	ShouldHaveSameTypeAs    = assertions.ShouldHaveSameTypeAs
+	ShouldNotHaveSameTypeAs = assertions.ShouldNotHaveSameTypeAs
+	ShouldImplement         = assertions.ShouldImplement
+	ShouldNotImplement      = assertions.ShouldNotImplement
+
+	ShouldHappenBefore         = assertions.ShouldHappenBefore
+	ShouldHappenOnOrBefore     = assertions.ShouldHappenOnOrBefore
+	ShouldHappenAfter          = assertions.ShouldHappenAfter
+	ShouldHappenOnOrAfter      = assertions.ShouldHappenOnOrAfter
+	ShouldHappenBetween        = assertions.ShouldHappenBetween
+	ShouldHappenOnOrBetween    = assertions.ShouldHappenOnOrBetween
+	ShouldNotHappenOnOrBetween = assertions.ShouldNotHappenOnOrBetween
+	ShouldHappenWithin         = assertions.ShouldHappenWithin
+	ShouldNotHappenWithin      = assertions.ShouldNotHappenWithin
+	ShouldBeChronological      = assertions.ShouldBeChronological
+)

--- a/vendor/github.com/smartystreets/goconvey/convey/context.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/context.go
@@ -1,0 +1,272 @@
+package convey
+
+import (
+	"fmt"
+
+	"github.com/jtolds/gls"
+	"github.com/smartystreets/goconvey/convey/reporting"
+)
+
+type conveyErr struct {
+	fmt    string
+	params []interface{}
+}
+
+func (e *conveyErr) Error() string {
+	return fmt.Sprintf(e.fmt, e.params...)
+}
+
+func conveyPanic(fmt string, params ...interface{}) {
+	panic(&conveyErr{fmt, params})
+}
+
+const (
+	missingGoTest = `Top-level calls to Convey(...) need a reference to the *testing.T.
+		Hint: Convey("description here", t, func() { /* notice that the second argument was the *testing.T (t)! */ }) `
+	extraGoTest    = `Only the top-level call to Convey(...) needs a reference to the *testing.T.`
+	noStackContext = "Convey operation made without context on goroutine stack.\n" +
+		"Hint: Perhaps you meant to use `Convey(..., func(c C){...})` ?"
+	differentConveySituations = "Different set of Convey statements on subsequent pass!\nDid not expect %#v."
+	multipleIdenticalConvey   = "Multiple convey suites with identical names: %#v"
+)
+
+const (
+	failureHalt = "___FAILURE_HALT___"
+
+	nodeKey = "node"
+)
+
+///////////////////////////////// Stack Context /////////////////////////////////
+
+func getCurrentContext() *context {
+	ctx, ok := ctxMgr.GetValue(nodeKey)
+	if ok {
+		return ctx.(*context)
+	}
+	return nil
+}
+
+func mustGetCurrentContext() *context {
+	ctx := getCurrentContext()
+	if ctx == nil {
+		conveyPanic(noStackContext)
+	}
+	return ctx
+}
+
+//////////////////////////////////// Context ////////////////////////////////////
+
+// context magically handles all coordination of Convey's and So assertions.
+//
+// It is tracked on the stack as goroutine-local-storage with the gls package,
+// or explicitly if the user decides to call convey like:
+//
+//   Convey(..., func(c C) {
+//     c.So(...)
+//   })
+//
+// This implements the `C` interface.
+type context struct {
+	reporter reporting.Reporter
+
+	children map[string]*context
+
+	resets []func()
+
+	executedOnce   bool
+	expectChildRun *bool
+	complete       bool
+
+	focus       bool
+	failureMode FailureMode
+}
+
+// rootConvey is the main entry point to a test suite. This is called when
+// there's no context in the stack already, and items must contain a `t` object,
+// or this panics.
+func rootConvey(items ...interface{}) {
+	entry := discover(items)
+
+	if entry.Test == nil {
+		conveyPanic(missingGoTest)
+	}
+
+	expectChildRun := true
+	ctx := &context{
+		reporter: buildReporter(),
+
+		children: make(map[string]*context),
+
+		expectChildRun: &expectChildRun,
+
+		focus:       entry.Focus,
+		failureMode: defaultFailureMode.combine(entry.FailMode),
+	}
+	ctxMgr.SetValues(gls.Values{nodeKey: ctx}, func() {
+		ctx.reporter.BeginStory(reporting.NewStoryReport(entry.Test))
+		defer ctx.reporter.EndStory()
+
+		for ctx.shouldVisit() {
+			ctx.conveyInner(entry.Situation, entry.Func)
+			expectChildRun = true
+		}
+	})
+}
+
+//////////////////////////////////// Methods ////////////////////////////////////
+
+func (ctx *context) SkipConvey(items ...interface{}) {
+	ctx.Convey(items, skipConvey)
+}
+
+func (ctx *context) FocusConvey(items ...interface{}) {
+	ctx.Convey(items, focusConvey)
+}
+
+func (ctx *context) Convey(items ...interface{}) {
+	entry := discover(items)
+
+	// we're a branch, or leaf (on the wind)
+	if entry.Test != nil {
+		conveyPanic(extraGoTest)
+	}
+	if ctx.focus && !entry.Focus {
+		return
+	}
+
+	var inner_ctx *context
+	if ctx.executedOnce {
+		var ok bool
+		inner_ctx, ok = ctx.children[entry.Situation]
+		if !ok {
+			conveyPanic(differentConveySituations, entry.Situation)
+		}
+	} else {
+		if _, ok := ctx.children[entry.Situation]; ok {
+			conveyPanic(multipleIdenticalConvey, entry.Situation)
+		}
+		inner_ctx = &context{
+			reporter: ctx.reporter,
+
+			children: make(map[string]*context),
+
+			expectChildRun: ctx.expectChildRun,
+
+			focus:       entry.Focus,
+			failureMode: ctx.failureMode.combine(entry.FailMode),
+		}
+		ctx.children[entry.Situation] = inner_ctx
+	}
+
+	if inner_ctx.shouldVisit() {
+		ctxMgr.SetValues(gls.Values{nodeKey: inner_ctx}, func() {
+			inner_ctx.conveyInner(entry.Situation, entry.Func)
+		})
+	}
+}
+
+func (ctx *context) SkipSo(stuff ...interface{}) {
+	ctx.assertionReport(reporting.NewSkipReport())
+}
+
+func (ctx *context) So(actual interface{}, assert assertion, expected ...interface{}) {
+	if result := assert(actual, expected...); result == assertionSuccess {
+		ctx.assertionReport(reporting.NewSuccessReport())
+	} else {
+		ctx.assertionReport(reporting.NewFailureReport(result))
+	}
+}
+
+func (ctx *context) Reset(action func()) {
+	/* TODO: Failure mode configuration */
+	ctx.resets = append(ctx.resets, action)
+}
+
+func (ctx *context) Print(items ...interface{}) (int, error) {
+	fmt.Fprint(ctx.reporter, items...)
+	return fmt.Print(items...)
+}
+
+func (ctx *context) Println(items ...interface{}) (int, error) {
+	fmt.Fprintln(ctx.reporter, items...)
+	return fmt.Println(items...)
+}
+
+func (ctx *context) Printf(format string, items ...interface{}) (int, error) {
+	fmt.Fprintf(ctx.reporter, format, items...)
+	return fmt.Printf(format, items...)
+}
+
+//////////////////////////////////// Private ////////////////////////////////////
+
+// shouldVisit returns true iff we should traverse down into a Convey. Note
+// that just because we don't traverse a Convey this time, doesn't mean that
+// we may not traverse it on a subsequent pass.
+func (c *context) shouldVisit() bool {
+	return !c.complete && *c.expectChildRun
+}
+
+// conveyInner is the function which actually executes the user's anonymous test
+// function body. At this point, Convey or RootConvey has decided that this
+// function should actually run.
+func (ctx *context) conveyInner(situation string, f func(C)) {
+	// Record/Reset state for next time.
+	defer func() {
+		ctx.executedOnce = true
+
+		// This is only needed at the leaves, but there's no harm in also setting it
+		// when returning from branch Convey's
+		*ctx.expectChildRun = false
+	}()
+
+	// Set up+tear down our scope for the reporter
+	ctx.reporter.Enter(reporting.NewScopeReport(situation))
+	defer ctx.reporter.Exit()
+
+	// Recover from any panics in f, and assign the `complete` status for this
+	// node of the tree.
+	defer func() {
+		ctx.complete = true
+		if problem := recover(); problem != nil {
+			if problem, ok := problem.(*conveyErr); ok {
+				panic(problem)
+			}
+			if problem != failureHalt {
+				ctx.reporter.Report(reporting.NewErrorReport(problem))
+			}
+		} else {
+			for _, child := range ctx.children {
+				if !child.complete {
+					ctx.complete = false
+					return
+				}
+			}
+		}
+	}()
+
+	// Resets are registered as the `f` function executes, so nil them here.
+	// All resets are run in registration order (FIFO).
+	ctx.resets = []func(){}
+	defer func() {
+		for _, r := range ctx.resets {
+			// panics handled by the previous defer
+			r()
+		}
+	}()
+
+	if f == nil {
+		// if f is nil, this was either a Convey(..., nil), or a SkipConvey
+		ctx.reporter.Report(reporting.NewSkipReport())
+	} else {
+		f(ctx)
+	}
+}
+
+// assertionReport is a helper for So and SkipSo which makes the report and
+// then possibly panics, depending on the current context's failureMode.
+func (ctx *context) assertionReport(r *reporting.AssertionResult) {
+	ctx.reporter.Report(r)
+	if r.Failure != "" && ctx.failureMode == FailureHalts {
+		panic(failureHalt)
+	}
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/convey.goconvey
+++ b/vendor/github.com/smartystreets/goconvey/convey/convey.goconvey
@@ -1,0 +1,4 @@
+#ignore
+-timeout=1s
+#-covermode=count
+#-coverpkg=github.com/smartystreets/goconvey/convey,github.com/smartystreets/goconvey/convey/gotest,github.com/smartystreets/goconvey/convey/reporting

--- a/vendor/github.com/smartystreets/goconvey/convey/discovery.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/discovery.go
@@ -1,0 +1,103 @@
+package convey
+
+type actionSpecifier uint8
+
+const (
+	noSpecifier actionSpecifier = iota
+	skipConvey
+	focusConvey
+)
+
+type suite struct {
+	Situation string
+	Test      t
+	Focus     bool
+	Func      func(C) // nil means skipped
+	FailMode  FailureMode
+}
+
+func newSuite(situation string, failureMode FailureMode, f func(C), test t, specifier actionSpecifier) *suite {
+	ret := &suite{
+		Situation: situation,
+		Test:      test,
+		Func:      f,
+		FailMode:  failureMode,
+	}
+	switch specifier {
+	case skipConvey:
+		ret.Func = nil
+	case focusConvey:
+		ret.Focus = true
+	}
+	return ret
+}
+
+func discover(items []interface{}) *suite {
+	name, items := parseName(items)
+	test, items := parseGoTest(items)
+	failure, items := parseFailureMode(items)
+	action, items := parseAction(items)
+	specifier, items := parseSpecifier(items)
+
+	if len(items) != 0 {
+		conveyPanic(parseError)
+	}
+
+	return newSuite(name, failure, action, test, specifier)
+}
+func item(items []interface{}) interface{} {
+	if len(items) == 0 {
+		conveyPanic(parseError)
+	}
+	return items[0]
+}
+func parseName(items []interface{}) (string, []interface{}) {
+	if name, parsed := item(items).(string); parsed {
+		return name, items[1:]
+	}
+	conveyPanic(parseError)
+	panic("never get here")
+}
+func parseGoTest(items []interface{}) (t, []interface{}) {
+	if test, parsed := item(items).(t); parsed {
+		return test, items[1:]
+	}
+	return nil, items
+}
+func parseFailureMode(items []interface{}) (FailureMode, []interface{}) {
+	if mode, parsed := item(items).(FailureMode); parsed {
+		return mode, items[1:]
+	}
+	return FailureInherits, items
+}
+func parseAction(items []interface{}) (func(C), []interface{}) {
+	switch x := item(items).(type) {
+	case nil:
+		return nil, items[1:]
+	case func(C):
+		return x, items[1:]
+	case func():
+		return func(C) { x() }, items[1:]
+	}
+	conveyPanic(parseError)
+	panic("never get here")
+}
+func parseSpecifier(items []interface{}) (actionSpecifier, []interface{}) {
+	if len(items) == 0 {
+		return noSpecifier, items
+	}
+	if spec, ok := items[0].(actionSpecifier); ok {
+		return spec, items[1:]
+	}
+	conveyPanic(parseError)
+	panic("never get here")
+}
+
+// This interface allows us to pass the *testing.T struct
+// throughout the internals of this package without ever
+// having to import the "testing" package.
+type t interface {
+	Fail()
+}
+
+const parseError = "You must provide a name (string), then a *testing.T (if in outermost scope), an optional FailureMode, and then an action (func())."

--- a/vendor/github.com/smartystreets/goconvey/convey/doc.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/doc.go
@@ -1,0 +1,218 @@
+// Package convey contains all of the public-facing entry points to this project.
+// This means that it should never be required of the user to import any other
+// packages from this project as they serve internal purposes.
+package convey
+
+import "github.com/smartystreets/goconvey/convey/reporting"
+
+////////////////////////////////// suite //////////////////////////////////
+
+// C is the Convey context which you can optionally obtain in your action
+// by calling Convey like:
+//
+//   Convey(..., func(c C) {
+//     ...
+//   })
+//
+// See the documentation on Convey for more details.
+//
+// All methods in this context behave identically to the global functions of the
+// same name in this package.
+type C interface {
+	Convey(items ...interface{})
+	SkipConvey(items ...interface{})
+	FocusConvey(items ...interface{})
+
+	So(actual interface{}, assert assertion, expected ...interface{})
+	SkipSo(stuff ...interface{})
+
+	Reset(action func())
+
+	Println(items ...interface{}) (int, error)
+	Print(items ...interface{}) (int, error)
+	Printf(format string, items ...interface{}) (int, error)
+}
+
+// Convey is the method intended for use when declaring the scopes of
+// a specification. Each scope has a description and a func() which may contain
+// other calls to Convey(), Reset() or Should-style assertions. Convey calls can
+// be nested as far as you see fit.
+//
+// IMPORTANT NOTE: The top-level Convey() within a Test method
+// must conform to the following signature:
+//
+//     Convey(description string, t *testing.T, action func())
+//
+// All other calls should look like this (no need to pass in *testing.T):
+//
+//     Convey(description string, action func())
+//
+// Don't worry, goconvey will panic if you get it wrong so you can fix it.
+//
+// Additionally, you may explicitly obtain access to the Convey context by doing:
+//
+//     Convey(description string, action func(c C))
+//
+// You may need to do this if you want to pass the context through to a
+// goroutine, or to close over the context in a handler to a library which
+// calls your handler in a goroutine (httptest comes to mind).
+//
+// All Convey()-blocks also accept an optional parameter of FailureMode which sets
+// how goconvey should treat failures for So()-assertions in the block and
+// nested blocks. See the constants in this file for the available options.
+//
+// By default it will inherit from its parent block and the top-level blocks
+// default to the FailureHalts setting.
+//
+// This parameter is inserted before the block itself:
+//
+//     Convey(description string, t *testing.T, mode FailureMode, action func())
+//     Convey(description string, mode FailureMode, action func())
+//
+// See the examples package for, well, examples.
+func Convey(items ...interface{}) {
+	if ctx := getCurrentContext(); ctx == nil {
+		rootConvey(items...)
+	} else {
+		ctx.Convey(items...)
+	}
+}
+
+// SkipConvey is analagous to Convey except that the scope is not executed
+// (which means that child scopes defined within this scope are not run either).
+// The reporter will be notified that this step was skipped.
+func SkipConvey(items ...interface{}) {
+	Convey(append(items, skipConvey)...)
+}
+
+// FocusConvey is has the inverse effect of SkipConvey. If the top-level
+// Convey is changed to `FocusConvey`, only nested scopes that are defined
+// with FocusConvey will be run. The rest will be ignored completely. This
+// is handy when debugging a large suite that runs a misbehaving function
+// repeatedly as you can disable all but one of that function
+// without swaths of `SkipConvey` calls, just a targeted chain of calls
+// to FocusConvey.
+func FocusConvey(items ...interface{}) {
+	Convey(append(items, focusConvey)...)
+}
+
+// Reset registers a cleanup function to be run after each Convey()
+// in the same scope. See the examples package for a simple use case.
+func Reset(action func()) {
+	mustGetCurrentContext().Reset(action)
+}
+
+/////////////////////////////////// Assertions ///////////////////////////////////
+
+// assertion is an alias for a function with a signature that the convey.So()
+// method can handle. Any future or custom assertions should conform to this
+// method signature. The return value should be an empty string if the assertion
+// passes and a well-formed failure message if not.
+type assertion func(actual interface{}, expected ...interface{}) string
+
+const assertionSuccess = ""
+
+// So is the means by which assertions are made against the system under test.
+// The majority of exported names in the assertions package begin with the word
+// 'Should' and describe how the first argument (actual) should compare with any
+// of the final (expected) arguments. How many final arguments are accepted
+// depends on the particular assertion that is passed in as the assert argument.
+// See the examples package for use cases and the assertions package for
+// documentation on specific assertion methods. A failing assertion will
+// cause t.Fail() to be invoked--you should never call this method (or other
+// failure-inducing methods) in your test code. Leave that to GoConvey.
+func So(actual interface{}, assert assertion, expected ...interface{}) {
+	mustGetCurrentContext().So(actual, assert, expected...)
+}
+
+// SkipSo is analagous to So except that the assertion that would have been passed
+// to So is not executed and the reporter is notified that the assertion was skipped.
+func SkipSo(stuff ...interface{}) {
+	mustGetCurrentContext().SkipSo()
+}
+
+// FailureMode is a type which determines how the So() blocks should fail
+// if their assertion fails. See constants further down for acceptable values
+type FailureMode string
+
+const (
+
+	// FailureContinues is a failure mode which prevents failing
+	// So()-assertions from halting Convey-block execution, instead
+	// allowing the test to continue past failing So()-assertions.
+	FailureContinues FailureMode = "continue"
+
+	// FailureHalts is the default setting for a top-level Convey()-block
+	// and will cause all failing So()-assertions to halt further execution
+	// in that test-arm and continue on to the next arm.
+	FailureHalts FailureMode = "halt"
+
+	// FailureInherits is the default setting for failure-mode, it will
+	// default to the failure-mode of the parent block. You should never
+	// need to specify this mode in your tests..
+	FailureInherits FailureMode = "inherits"
+)
+
+func (f FailureMode) combine(other FailureMode) FailureMode {
+	if other == FailureInherits {
+		return f
+	}
+	return other
+}
+
+var defaultFailureMode FailureMode = FailureHalts
+
+// SetDefaultFailureMode allows you to specify the default failure mode
+// for all Convey blocks. It is meant to be used in an init function to
+// allow the default mode to be changdd across all tests for an entire packgae
+// but it can be used anywhere.
+func SetDefaultFailureMode(mode FailureMode) {
+	if mode == FailureContinues || mode == FailureHalts {
+		defaultFailureMode = mode
+	} else {
+		panic("You may only use the constants named 'FailureContinues' and 'FailureHalts' as default failure modes.")
+	}
+}
+
+//////////////////////////////////// Print functions ////////////////////////////////////
+
+// Print is analogous to fmt.Print (and it even calls fmt.Print). It ensures that
+// output is aligned with the corresponding scopes in the web UI.
+func Print(items ...interface{}) (written int, err error) {
+	return mustGetCurrentContext().Print(items...)
+}
+
+// Print is analogous to fmt.Println (and it even calls fmt.Println). It ensures that
+// output is aligned with the corresponding scopes in the web UI.
+func Println(items ...interface{}) (written int, err error) {
+	return mustGetCurrentContext().Println(items...)
+}
+
+// Print is analogous to fmt.Printf (and it even calls fmt.Printf). It ensures that
+// output is aligned with the corresponding scopes in the web UI.
+func Printf(format string, items ...interface{}) (written int, err error) {
+	return mustGetCurrentContext().Printf(format, items...)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+// SuppressConsoleStatistics prevents automatic printing of console statistics.
+// Calling PrintConsoleStatistics explicitly will force printing of statistics.
+func SuppressConsoleStatistics() {
+	reporting.SuppressConsoleStatistics()
+}
+
+// ConsoleStatistics may be called at any time to print assertion statistics.
+// Generally, the best place to do this would be in a TestMain function,
+// after all tests have been run. Something like this:
+//
+// func TestMain(m *testing.M) {
+//     convey.SuppressConsoleStatistics()
+//     result := m.Run()
+//     convey.PrintConsoleStatistics()
+//     os.Exit(result)
+// }
+//
+func PrintConsoleStatistics() {
+	reporting.PrintConsoleStatistics()
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/init.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/init.go
@@ -1,0 +1,81 @@
+package convey
+
+import (
+	"flag"
+	"os"
+
+	"github.com/jtolds/gls"
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/goconvey/convey/reporting"
+)
+
+func init() {
+	assertions.GoConveyMode(true)
+
+	declareFlags()
+
+	ctxMgr = gls.NewContextManager()
+}
+
+func declareFlags() {
+	flag.BoolVar(&json, "convey-json", false, "When true, emits results in JSON blocks. Default: 'false'")
+	flag.BoolVar(&silent, "convey-silent", false, "When true, all output from GoConvey is suppressed.")
+	flag.BoolVar(&story, "convey-story", false, "When true, emits story output, otherwise emits dot output. When not provided, this flag mirros the value of the '-test.v' flag")
+
+	if noStoryFlagProvided() {
+		story = verboseEnabled
+	}
+
+	// FYI: flag.Parse() is called from the testing package.
+}
+
+func noStoryFlagProvided() bool {
+	return !story && !storyDisabled
+}
+
+func buildReporter() reporting.Reporter {
+	selectReporter := os.Getenv("GOCONVEY_REPORTER")
+
+	switch {
+	case testReporter != nil:
+		return testReporter
+	case json || selectReporter == "json":
+		return reporting.BuildJsonReporter()
+	case silent || selectReporter == "silent":
+		return reporting.BuildSilentReporter()
+	case selectReporter == "dot":
+		// Story is turned on when verbose is set, so we need to check for dot reporter first.
+		return reporting.BuildDotReporter()
+	case story || selectReporter == "story":
+		return reporting.BuildStoryReporter()
+	default:
+		return reporting.BuildDotReporter()
+	}
+}
+
+var (
+	ctxMgr *gls.ContextManager
+
+	// only set by internal tests
+	testReporter reporting.Reporter
+)
+
+var (
+	json   bool
+	silent bool
+	story  bool
+
+	verboseEnabled = flagFound("-test.v=true")
+	storyDisabled  = flagFound("-story=false")
+)
+
+// flagFound parses the command line args manually for flags defined in other
+// packages. Like the '-v' flag from the "testing" package, for instance.
+func flagFound(flagValue string) bool {
+	for _, arg := range os.Args {
+		if arg == flagValue {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/smartystreets/goconvey/convey/nilReporter.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/nilReporter.go
@@ -1,0 +1,15 @@
+package convey
+
+import (
+	"github.com/smartystreets/goconvey/convey/reporting"
+)
+
+type nilReporter struct{}
+
+func (self *nilReporter) BeginStory(story *reporting.StoryReport)  {}
+func (self *nilReporter) Enter(scope *reporting.ScopeReport)       {}
+func (self *nilReporter) Report(report *reporting.AssertionResult) {}
+func (self *nilReporter) Exit()                                    {}
+func (self *nilReporter) EndStory()                                {}
+func (self *nilReporter) Write(p []byte) (int, error)              { return len(p), nil }
+func newNilReporter() *nilReporter                                 { return &nilReporter{} }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -73,6 +73,12 @@
 			"path": "github.com/mgutz/ansi",
 			"revision": "c286dcecd19ff979eeb73ea444e479b903f2cfcb",
 			"revisionTime": "2015-09-14T16:22:38Z"
+		},
+		{
+			"checksumSHA1": "/mwAihy9AmznMzmbPQ5nWJXBiRU=",
+			"path": "github.com/smartystreets/goconvey/convey",
+			"revision": "3c2572876754c4669ae7417b219f0b30a29b32c7",
+			"revisionTime": "2016-11-15T20:48:08Z"
 		}
 	],
 	"rootPath": "github.com/ONSdigital/dp-dd-frontend-controller"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,22 @@
 			"revisionTime": "2016-11-24T15:03:20Z"
 		},
 		{
-			"checksumSHA1": "Td5hMQr9U0Uabz+jL4mO0O7oKO4=",
+			"checksumSHA1": "8YsjCzHCgxAXz0KMsKPtev0xDuw=",
+			"path": "github.com/ONSdigital/dp-frontend-models/model/dd",
+			"revision": "b9e632e86a52a54f5b7ba7cf904f4482cf73ef63",
+			"revisionTime": "2016-12-01T13:23:39Z"
+		},
+		{
+			"checksumSHA1": "yEeAoLvNPSwzytiE/gFDxxIjGvc=",
+			"path": "github.com/ONSdigital/dp-frontend-models/model/dd/dataset",
+			"revision": "b9e632e86a52a54f5b7ba7cf904f4482cf73ef63",
+			"revisionTime": "2016-12-01T13:23:39Z"
+		},
+		{
+			"checksumSHA1": "uoGr/qxILN47jS+R1C2HcuxebhQ=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/dd/homepage",
-			"revision": "b88161482c2bc192ebedd85be45b259e56b1c74f",
-			"revisionTime": "2016-12-01T09:50:22Z"
+			"revision": "b9e632e86a52a54f5b7ba7cf904f4482cf73ef63",
+			"revisionTime": "2016-12-01T13:23:39Z"
 		},
 		{
 			"checksumSHA1": "J9OiPnhPHFPhQ+R+dq6LFj+dTxE=",


### PR DESCRIPTION
### What

Integrate the dp-dd-api-stub into the dd front-end controller and provide some basic routes that demonstrate fetching data from the API and rendering it.

### How to review

1. Download and build the dd-api-integration branches of this and the dp-frontend-renderer projects. 
2. Run the fronted-router, front-end renderer, and front-end controller.
3. Navigate to `http://localhost:20000/dd` to see the example dd homepage listing the sample datasets. Drill into a dataset to see a basic list of the dimensions in that dataset.

### Who can review

Anyone but me.