### PR TITLE
Add proxies to dd api and dd job creator api

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,5 +9,8 @@ var RendererURL = "http://localhost:20010"
 // DiscoveryAPIURL is the address of the data discovery REST API service.
 var DiscoveryAPIURL = "http://localhost:20099"
 
+// JobAPIRURL is the address of the data discovery download job creation service
+var JobAPIURL = "http://localhost:20100"
+
 // ExternalURL is the base URL through which users are accessing the service.
 var ExternalURL = "http://localhost:20000/dd"

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -3,12 +3,13 @@ package discovery
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ONSdigital/dp-dd-frontend-controller/config"
-	"github.com/ONSdigital/dp-frontend-models/model/dd"
-	"github.com/ONSdigital/go-ns/log"
 	"io"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/ONSdigital/dp-dd-frontend-controller/config"
+	"github.com/ONSdigital/dp-frontend-models/model/dd"
+	"github.com/ONSdigital/go-ns/log"
 )
 
 // ListDatasets lists the available datasets by querying the DD API.
@@ -50,30 +51,30 @@ func GetDataset(id string) (dataset *dd.Dataset, err error) {
 	request, err := http.NewRequest("GET", config.DiscoveryAPIURL+"/datasets/"+id, nil)
 	if err != nil {
 		log.Error(err, nil)
-		return
+		return nil, err
 	}
 
 	res, err := http.DefaultClient.Do(request)
 	if err != nil {
 		log.ErrorR(request, err, nil)
-		return
+		return nil, err
 	}
 	defer checkClose(res.Body)
 
 	if res.StatusCode != http.StatusOK {
 		err = fmt.Errorf("discovery.GetDataset: unexpected status code from API: %d", res.StatusCode)
-		return
+		return nil, err
 	}
 
 	datasetJSON, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		log.ErrorR(request, err, nil)
-		return
+		return nil, err
 	}
 
 	if err = json.Unmarshal(datasetJSON, &dataset); err != nil {
 		log.ErrorR(request, err, nil)
-		return
+		return nil, err
 	}
 
 	return

--- a/handlers/dataset/handler.go
+++ b/handlers/dataset/handler.go
@@ -1,12 +1,13 @@
 package dataset
 
 import (
+	"net/http"
+
 	"github.com/ONSdigital/dp-dd-frontend-controller/config"
 	"github.com/ONSdigital/dp-dd-frontend-controller/discovery"
 	"github.com/ONSdigital/dp-dd-frontend-controller/renderer"
 	"github.com/ONSdigital/dp-frontend-models/model/dd/dataset"
 	"github.com/ONSdigital/go-ns/log"
-	"net/http"
 )
 
 // Handler handles requests to the homepage
@@ -21,10 +22,10 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 		respond(w, http.StatusInternalServerError, []byte(err.Error()))
 		return
 	}
+	log.DebugR(req, `Got response from API`, log.Data{"datasetModel": datasetModel})
 
 	// Rewrite the URLs in the datasets to point to our own address
 	datasetModel.URL = config.ExternalURL + "/dataset/" + datasetModel.ID
-
 
 	page := dataset.Page{
 		Dataset: datasetModel,
@@ -46,4 +47,3 @@ func respond(w http.ResponseWriter, status int, body []byte) {
 		log.Error(err, nil)
 	}
 }
-

--- a/vendor/github.com/ONSdigital/go-ns/handlers/reverseProxy/reverseProxy.go
+++ b/vendor/github.com/ONSdigital/go-ns/handlers/reverseProxy/reverseProxy.go
@@ -1,0 +1,33 @@
+package reverseProxy
+
+import (
+	"net/url"
+	"net/http"
+	"net/http/httputil"
+	"net"
+	"time"
+)
+
+func Create(proxyURL *url.URL, directorFunc func(*http.Request)) http.Handler {
+	proxy := httputil.NewSingleHostReverseProxy(proxyURL)
+	director := proxy.Director
+	proxy.Transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	proxy.Director = func(req *http.Request) {
+		director(req)
+		req.Host = proxyURL.Host
+		if directorFunc != nil {
+			directorFunc(req)
+		}
+	}
+	return proxy
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -39,6 +39,12 @@
 			"revisionTime": "2016-11-22T11:02:49Z"
 		},
 		{
+			"checksumSHA1": "at4wziPfx6E+Jla/IELKhX88nGM=",
+			"path": "github.com/ONSdigital/go-ns/handlers/reverseProxy",
+			"revision": "e474198f686c1017ac5c7bfd6de682d7288d95b8",
+			"revisionTime": "2017-01-10T09:35:41Z"
+		},
+		{
 			"checksumSHA1": "HgL/HLG5D1WNPb1lrb/hpywtm9o=",
 			"path": "github.com/ONSdigital/go-ns/handlers/timeout",
 			"revision": "2876489f003065b44a7ae6b250c238b0efe8755e",


### PR DESCRIPTION
### What

Add proxy for api and job creator api, so they're both accessible through frontend router (:20000)

### How to review

Should probably be reviewed at the same time as the [other pull request](https://github.com/ONSdigital/dp-frontend-renderer/pull/16)

Locally the following requests should return 200s, with expected response from APIs:
- GET request to `localhost:20000/dd/api/datasets` should return all data discovery datasets.
- POST request to `localhost:20000/dd/api/jobs` should return an ID of a new job.
- GET request to `localhost:20000/dd/api/jobs/job/{id}` should return the status of the ID you got in the previous request.

### Who can review

Anyone but me, preferably @ian-kent 
