### PR TITLE
Front end shoud use dataset path

### DIFF
--- a/handlers/datasetList/handler.go
+++ b/handlers/datasetList/handler.go
@@ -23,7 +23,7 @@ func Handler(w http.ResponseWriter, req *http.Request) {
 
 	// Rewrite the URLs in the datasets to point to our own address
 	for _, dataset := range datasets.Items {
-		dataset.URL = config.ExternalURL + "/versions/" + dataset.ID
+		dataset.URL = config.ExternalURL + "/datasets/" + dataset.ID
 	}
 
 	page := datasetList.DatasetList{


### PR DESCRIPTION
### What

Endpoint `datasets` changed to `versions` but front-end should still be served from `datasets`

### How to review

Just run the full stack, upload file, click dataset link

### Who can review

Anyone but me. 
